### PR TITLE
changing context into an interface

### DIFF
--- a/layout/ctx/proto/interface.go
+++ b/layout/ctx/proto/interface.go
@@ -1,0 +1,33 @@
+package proto
+
+import (
+	"time"
+	
+	"github.com/cybriq/giocore/io/event"
+	"github.com/cybriq/giocore/op"
+	"github.com/cybriq/giocore/unit"
+	"github.com/cybriq/pokaz/layout/dim"
+)
+
+// Context is an interface for Gio contexts to expand their capabilities.
+//
+// The base context as found in Gio's version of layout.
+// Context is intentionally pass by value as there is no other data that is
+// important for this layout paint and input route process.
+//
+// However, in order to enable such things as viewports,
+// a context can serve as a mechanism to abstract the interface for the
+// client side while allowing other widgets to inspect some derived value
+// formed out of the composition of the layout tree,
+// by capturing its dimensions results in a form that can be searched for
+// presence inside a given viewport box.
+type Context interface {
+	Constraints() dim.Constraints
+	Metric() unit.Metric
+	Queue() event.Queue
+	Now() time.Time
+	Ops() *op.Ops
+	Px(v unit.Value) int
+	Events(k event.Tag) []event.Event
+	Disabled() Context
+}

--- a/layout/dim/dimensions.go
+++ b/layout/dim/dimensions.go
@@ -2,8 +2,8 @@ package dim
 
 import "image"
 
-//Dimensions define the dimensions of a widget, including a baseline for lining
-//up text
+// Dimensions define the dimensions of a widget, including a baseline for lining
+// up text
 type Dimensions struct {
 	Size     image.Point
 	Baseline int

--- a/layout/dir/direction.go
+++ b/layout/dir/direction.go
@@ -42,9 +42,11 @@ func (d Direction) String() string {
 func (d Direction) Fn(
 	gtx ctx.Context, w wdg.Widget,
 ) dim.Dimensions {
-	macro := op.Record(gtx.Ops)
-	cs := gtx.Constraints
-	gtx.Constraints.Min = image.Point{}
+	macro := op.Record(gtx.Ops())
+	cs := gtx.Constraints()
+	cstr := gtx.Constraints()
+	cstr.Min = image.Point{}
+	gtx.SetConstraints(cstr)
 	dims := w(gtx)
 	call := macro.Stop()
 	sz := dims.Size
@@ -55,10 +57,10 @@ func (d Direction) Fn(
 		sz.Y = cs.Min.Y
 	}
 
-	defer op.Save(gtx.Ops).Load()
+	defer op.Save(gtx.Ops()).Load()
 	p := d.Position(dims.Size, sz)
-	op.Offset(conv.Point(p)).Add(gtx.Ops)
-	call.Add(gtx.Ops)
+	op.Offset(conv.Point(p)).Add(gtx.Ops())
+	call.Add(gtx.Ops())
 
 	return dim.Dimensions{
 		Size:     sz,

--- a/layout/flex/struct.go
+++ b/layout/flex/struct.go
@@ -83,7 +83,7 @@ func flexed(weight float32, widget wdg.Widget) child {
 // specified order, but rigid children are laid out before flexed children.
 func (f flex) layout(gtx ctx.Context, children ...child) dim.Dimensions {
 	size := 0
-	cs := gtx.Constraints
+	cs := gtx.Constraints()
 	mainMin, mainMax := f.axis.MainConstraint(cs)
 	crossMin, crossMax := f.axis.CrossConstraint(cs)
 	remaining := mainMax
@@ -95,9 +95,9 @@ func (f flex) layout(gtx ctx.Context, children ...child) dim.Dimensions {
 			totalWeight += child.weight
 			continue
 		}
-		macro := op.Record(gtx.Ops)
-		cgtx.Constraints = f.axis.
-			Constraints(0, remaining, crossMin, crossMax)
+		macro := op.Record(gtx.Ops())
+		cgtx.SetConstraints(f.axis.
+			Constraints(0, remaining, crossMin, crossMax))
 		dm := child.widget(cgtx)
 		c := macro.Stop()
 		sz := f.axis.Convert(dm.Size).X
@@ -131,9 +131,10 @@ func (f flex) layout(gtx ctx.Context, children ...child) dim.Dimensions {
 				flexSize = remaining
 			}
 		}
-		macro := op.Record(gtx.Ops)
-		cgtx.Constraints = f.axis.Constraints(flexSize, flexSize, crossMin,
-			crossMax)
+		macro := op.Record(gtx.Ops())
+		cgtx.SetConstraints(
+			f.axis.Constraints(
+				flexSize, flexSize, crossMin, crossMax))
 		dm := child.widget(cgtx)
 		c := macro.Stop()
 		sz := f.axis.Convert(dm.Size).X
@@ -186,10 +187,10 @@ func (f flex) layout(gtx ctx.Context, children ...child) dim.Dimensions {
 				cross = maxBaseline - b
 			}
 		}
-		stack := op.Save(gtx.Ops)
+		stack := op.Save(gtx.Ops())
 		pt := f.axis.Convert(image.Pt(mainSize, cross))
-		op.Offset(conv.Point(pt)).Add(gtx.Ops)
-		child.call.Add(gtx.Ops)
+		op.Offset(conv.Point(pt)).Add(gtx.Ops())
+		child.call.Add(gtx.Ops())
 		stack.Load()
 		mainSize += f.axis.Convert(dm.Size).X
 		if i < len(children)-1 {

--- a/layout/inset/struct.go
+++ b/layout/inset/struct.go
@@ -24,7 +24,7 @@ func (in inset) layout(gtx ctx.Context, w wdg.Widget) dim.Dimensions {
 	right := gtx.Px(in.Right)
 	bottom := gtx.Px(in.Bottom)
 	left := gtx.Px(in.Left)
-	mcs := gtx.Constraints
+	mcs := gtx.Constraints()
 	mcs.Max.X -= left + right
 	if mcs.Max.X < 0 {
 		left = 0
@@ -43,9 +43,9 @@ func (in inset) layout(gtx ctx.Context, w wdg.Widget) dim.Dimensions {
 	if mcs.Min.Y > mcs.Max.Y {
 		mcs.Min.Y = mcs.Max.Y
 	}
-	stack := op.Save(gtx.Ops)
-	op.Offset(conv.Point(image.Point{X: left, Y: top})).Add(gtx.Ops)
-	gtx.Constraints = mcs
+	stack := op.Save(gtx.Ops())
+	op.Offset(conv.Point(image.Point{X: left, Y: top})).Add(gtx.Ops())
+	gtx.SetConstraints(mcs)
 	dm := w(gtx)
 	stack.Load()
 	return dim.Dimensions{

--- a/layout/space/space.go
+++ b/layout/space/space.go
@@ -13,12 +13,12 @@ type spacer struct {
 	Width, Height unit.Value
 }
 
-//Spacer makes a new spacer
+// Spacer makes a new spacer
 func Spacer(width, height float32) spacer {
 	return spacer{unit.Sp(width), unit.Sp(height)}
 }
 
-//Fn lays out a spacer
+// Fn lays out a spacer
 func (s spacer) Fn(gtx ctx.Context) dim.Dimensions {
 	return dim.Dimensions{
 		Size: image.Point{

--- a/layout/wdg/widget.go
+++ b/layout/wdg/widget.go
@@ -1,9 +1,9 @@
 package wdg
 
 import (
-	"github.com/cybriq/pokaz/layout/ctx"
+	"github.com/cybriq/pokaz/layout/ctx/proto"
 	"github.com/cybriq/pokaz/layout/dim"
 )
 
 // Widget is a generic function that adds some kind of ops to a layout rectangle
-type Widget func(gtx ctx.Context) dim.Dimensions
+type Widget func(gtx proto.Context) dim.Dimensions


### PR DESCRIPTION
all existing widget/layout code now expects an interface which is not much more complicated than the original but now can have differing implementations for widget-specific purposes such as a viewport or even automated linting and a grammar of what can contain what.